### PR TITLE
Performance: use css translate for traitlineconnector

### DIFF
--- a/packages/gw2-ui-components/src/TraitLineConnector/TraitLineConnector.jsx
+++ b/packages/gw2-ui-components/src/TraitLineConnector/TraitLineConnector.jsx
@@ -106,12 +106,12 @@ const TraitLineConnector = forwardRef(
               ...(!disabled && {
                 backgroundImage: `url(${traitLineConnectorImage})`,
                 backgroundRepeat: 'repeat-x',
-                animation: `${move.toString()} 5s linear infinite`,
+                animation: `${move.toString()} 10s linear infinite`,
               }),
             }}
             css={{
               height: 8,
-              width: 43 * 2,
+              width: 43 * 4,
             }}
           />
         </div>

--- a/packages/gw2-ui-components/src/TraitLineConnector/TraitLineConnector.jsx
+++ b/packages/gw2-ui-components/src/TraitLineConnector/TraitLineConnector.jsx
@@ -7,10 +7,10 @@ import traitLineConnectorImage from '../assets/images/trait-line-connector.png'
 
 const move = keyframes({
   from: {
-    backgroundPositionX: 0,
+    transform: 'translateX(0)',
   },
   to: {
-    backgroundPositionX: -300,
+    transform: 'translateX(-50%)',
   },
 })
 
@@ -91,22 +91,30 @@ const TraitLineConnector = forwardRef(
         {resizeListener}
 
         <div
-          sx={{
-            position: 'absolute',
-            ...(!disabled && {
-              backgroundImage: `url(${traitLineConnectorImage})`,
-              backgroundRepeat: 'repeat-x',
-              animation: `${move.toString()} 30s linear infinite`,
-            }),
-          }}
           css={{
+            position: 'absolute',
             height: 8,
             bottom,
             left,
             width: length,
             transform: `rotate(${angle}deg)`,
+            overflow: 'hidden',
           }}
-        />
+        >
+          <div
+            sx={{
+              ...(!disabled && {
+                backgroundImage: `url(${traitLineConnectorImage})`,
+                backgroundRepeat: 'repeat-x',
+                animation: `${move.toString()} 5s linear infinite`,
+              }),
+            }}
+            css={{
+              height: 8,
+              width: 43 * 2,
+            }}
+          />
+        </div>
       </div>
     )
   },


### PR DESCRIPTION
This modifies the TraitLineConnector component to reduce the performance impact of its animation.

Currently, the CSS animation modifies `background-position`. This causes a style recalculation (I think of the whole page?) and a repaint (just of the connector) every animation frame. See: https://developer.mozilla.org/en-US/docs/Web/Performance/Animation_performance_and_frame_rate#css_property_cost. This uses about 20% of the main thread per traitline component on my laptop, rendering 30fps with about a 10-15W power increase over having the animation paused.

As per that link, doing an animation without a repaint limits one to the `transform` effect, which can't specifically target background images. Thus, this PR replaces the background with a nested `div` element ~twice as large as the connector, animates it to move with `transform`, and sets `overflow: 'hidden'` on the connector to mask the right area.

Unfortunately, this only saves like 2-3 watts in identical circumstances to the old code. But it saves the entire 10-15W when the component is offscreen, saves the entire main thread CPU usage, and renders at twice the frame rate.