### PR TITLE
Performance: use 15fps for traitline connector animation

### DIFF
--- a/packages/gw2-ui-components/src/TraitLineConnector/TraitLineConnector.jsx
+++ b/packages/gw2-ui-components/src/TraitLineConnector/TraitLineConnector.jsx
@@ -106,7 +106,7 @@ const TraitLineConnector = forwardRef(
               ...(!disabled && {
                 backgroundImage: `url(${traitLineConnectorImage})`,
                 backgroundRepeat: 'repeat-x',
-                animation: `${move.toString()} 10s linear infinite`,
+                animation: `${move.toString()} 10s steps(150) infinite`,
               }),
             }}
             css={{

--- a/packages/gw2-ui-components/src/TraitLineConnector/TraitLineConnector.jsx
+++ b/packages/gw2-ui-components/src/TraitLineConnector/TraitLineConnector.jsx
@@ -106,7 +106,9 @@ const TraitLineConnector = forwardRef(
               ...(!disabled && {
                 backgroundImage: `url(${traitLineConnectorImage})`,
                 backgroundRepeat: 'repeat-x',
-                animation: `${move.toString()} 10s steps(150) infinite`,
+                '@media screen and (prefers-reduced-motion: no-preference)': {
+                  animation: `${move.toString()} 10s steps(150) infinite`,
+                },
               }),
             }}
             css={{


### PR DESCRIPTION
Yes, yes, I realize this is an obsession at this point :P

This drops the frame rate of the traitline connector animation to a smooth 15, which isn't noticeable but drops its power draw to about 3 watts per visible traitline, finally making my fans not spin up.