### PR TITLE
chore: fix eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,8 +7,7 @@
   "extends": [
     "airbnb",
     "plugin:prettier/recommended",
-    "prettier/react",
-    "prettier/standard"
+    "prettier"
   ],
   "settings": {
     "react": {


### PR DESCRIPTION
This fixes the eslint config for 93798adeabcd0c6ea1b991ead50efcc6a60722c7.